### PR TITLE
refactor: Move notes to footnotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > Just when you thought, Python could not be more fun.
 
-### 1. Hello World
+### 1. Hello World[^hello-world]
 
 ```py
 >>> import __hello__
@@ -20,7 +20,7 @@ Hello World!
 Hello World!
 ```
 
-### 2. The classic
+### 2. The classic[^the-classic]
 ```
 >>> import this
 
@@ -47,12 +47,12 @@ If the implementation is easy to explain, it may be a good idea.
 Namespaces are one honking great idea -- let's do more of those!
 ```
 
-### 3. The missing line from the classic
+### 3. The missing line from the classic[^missing-zen]
 
 The Zen of Python was introduced in [PEP 20](https://www.python.org/dev/peps/pep-0020/#id2). It is supposed to be 20 aphorisms, but only 19 of which have been written down.
 
 
-### 4. A simple life lesson
+### 4. A simple life lesson[^import-this]
 ```py
 >>> import this
 ...
@@ -69,22 +69,22 @@ True
 True
 ```
 
-### 5. Comics, yeah.
+### 5. Comics, yeah.[^antigravity]
 ```py
 >>> import antigravity
 ```
 
-### 6. It's not a choice, it defines who we are
+### 6. It's not a choice, it defines who we are[^braces]
 ```py
 >>> from __future__ import braces
   File "<stdin>", line 1
 SyntaxError: not a chance
 ```
 
-### 7. Origins
+### 7. Origins[^origins]
 The name Python has nothing to do with the type of Snake.
 
-### 8. The confuscation
+### 8. The confuscation[^this-py]
 This is how the `this.py` module looks, which prints the Zen of Python.
 
 ```py
@@ -122,13 +122,13 @@ The code for the Zen violates itself. It's not beautiful but ugly, not explicit 
 This would probably be the *only* module to go against the spirit of what it says itself.
 .
 
-### 9. C/C++ anyone?
+### 9. C/C++ anyone?[^c-c++]
 From the Zen again,
 ```
 There should be one-- and preferably only one --obvious way to do it.
 ```
 
-### 10. Naming identifiers can be unspeakably cool
+### 10. Naming identifiers can be unspeakably cool[^identifiers]
 Just when you thought that working in Python couldn't possibly *be* any more fun,
 ```py
 >>> from math import pi
@@ -140,7 +140,7 @@ Just when you thought that working in Python couldn't possibly *be* any more fun
 True
 ```
 
-### 11. Picking a place for meetup?
+### 11. Picking a place for meetup?[^geohash]
 ```py
 >>> from antigravity import geohash
 >>> # Your location, a date and that date's (or most recent) DJIA opening.
@@ -150,7 +150,7 @@ True
 This can generate a GPS coordinate in a region which is 1 longitude long and 1
 latitude wide based on your location.
 
-### 12. The FLUFL - Friendly Language Uncle For Life from [PEP 401 -- BDFL Retirement](https://www.python.org/dev/peps/pep-0401)
+### 12. The FLUFL - Friendly Language Uncle For Life from [PEP 401 -- BDFL Retirement](https://www.python.org/dev/peps/pep-0401)[^pep-401]
 ```py
 >>> from __future__ import barry_as_FLUFL
 >>> 1 <> 2
@@ -163,7 +163,7 @@ SyntaxError: invalid syntax
 ```
 Recognized that the != inequality operator in Python 3.0 was a horrible, finger pain inducing mistake, the FLUFL reinstates the <> diamond operator as the sole spelling.
 
-### 13. InPynite?
+### 13. InPynite?[^inpynite]
 ```py
 >>> infinity = float('infinity')
 >>> hash(infinity)
@@ -193,7 +193,7 @@ class code(object)
  ...
  ```
 
-### 15. Python 3.9 PEG parser
+### 15. Python 3.9 PEG parser[^peg-parser]
 `__peg_parser__` is a keyword in python 3.9, will throw a syntax error if used
 ```py
 >>> __peg_parser__
@@ -203,21 +203,20 @@ class code(object)
 SyntaxError: You found it!
 ```
 
-## Notes
-1. Easiest hello world program in a language without calling any function
-2. Each and every line is the philosophy of Python's design and is a supreme holy guide
-3. Maybe just to show that there always should be a new line at the end of a file!
-4. Not an easter egg, a joke in the interpreter
-5. It opens this [xkcd comic](https://xkcd.com/353) which demonstrates how easy it is to do stuff with modules
-6. This is to instantly close down any conversation about introducing curly braces to Python
-7. Guido van Rossum is a big fan of [Monty Python's Flying Circus](https://en.wikipedia.org/wiki/Monty_Python%27s_Flying_Circus)
-8. It's a substitution cipher called [ROT13](https://en.wikipedia.org/wiki/ROT13)
-9. In many languages there are two ways to do the same thing `--no` and `no--`. The message has a hidden example in itself
-10. Support for unicode character set for naming identifiers was added in Python3. Though, it is not explicitly preferred while writing code, it adds flavour to working with scientific formulas
-11. The original code is [here](https://github.com/python/cpython/blob/master/Lib/antigravity.py) with the [xkcd comic](https://xkcd.com/426/) referenced, and maybe that's why this is also in the `antigravity` module
-12. The [PEP 401](https://www.python.org/dev/peps/pep-0401/) is an April Fools' Joke - The PEP's number is 401, i.e. 4/01 or April 1st (April Fools' Day). The PEP states that Guido van Rossum is stepping down. The new title given to him would be pronounced "BDEVIL" (Benevolent Dictator Emeritus Vacationing Indefinitely from the Language) and Guido's successor will be Barry Warsaw, or as he is affectionately known, Uncle Barry. Uncle Barry's official title is "FLUFL" (Friendly Language Uncle For Life). There are in-jokes about the Parrot virtual machine and the "non-existent" Python Secret Underground (possibly a throw-back to ["TINC" on USENET](https://en.wikipedia.org/wiki/There_Is_No_Cabal)).
-13. [Source](https://www.reddit.com/r/Python/comments/6wrd8t/nice_lil_easter_egg_i_suppose/).
-14. See [this answer](https://stackoverflow.com/a/65487013/14362510)
+[^hello-world]: Easiest hello world program in a language without calling any function
+[^the-classic]: Each and every line is the philosophy of Python's design and is a supreme holy guide
+[^missing-zen]: Maybe just to show that there always should be a new line at the end of a file!
+[^import-this]: Not an easter egg, a joke in the interpreter
+[^antigravity]: It opens this [xkcd comic](https://xkcd.com/353) which demonstrates how easy it is to do stuff with modules
+[^braces]: This is to instantly close down any conversation about introducing curly braces to Python
+[^origins]: Guido van Rossum is a big fan of [Monty Python's Flying Circus](https://en.wikipedia.org/wiki/Monty_Python%27s_Flying_Circus)
+[^this-py]: It's a substitution cipher called [ROT13](https://en.wikipedia.org/wiki/ROT13)
+[^c-c++]: In many languages there are two ways to do the same thing `--no` and `no--`. The message has a hidden example in itself
+[^identifiers]: Support for unicode character set for naming identifiers was added in Python3. Though, it is not explicitly preferred while writing code, it adds flavour to working with scientific formulas
+[^geohash]: The original code is [here](https://github.com/python/cpython/blob/master/Lib/antigravity.py) with the [xkcd comic](https://xkcd.com/426/) referenced, and maybe that's why this is also in the `antigravity` module
+[^pep-401]: The [PEP 401](https://www.python.org/dev/peps/pep-0401/) is an April Fools' Joke - The PEP's number is 401, i.e. 4/01 or April 1st (April Fools' Day). The PEP states that Guido van Rossum is stepping down. The new title given to him would be pronounced "BDEVIL" (Benevolent Dictator Emeritus Vacationing Indefinitely from the Language) and Guido's successor will be Barry Warsaw, or as he is affectionately known, Uncle Barry. Uncle Barry's official title is "FLUFL" (Friendly Language Uncle For Life). There are in-jokes about the Parrot virtual machine and the "non-existent" Python Secret Underground (possibly a throw-back to ["TINC" on USENET](https://en.wikipedia.org/wiki/There_Is_No_Cabal)).
+[^inpynite]: [Source](https://www.reddit.com/r/Python/comments/6wrd8t/nice_lil_easter_egg_i_suppose/).
+[^peg-parser]: See [this answer](https://stackoverflow.com/a/65487013/14362510)
 
 ## Add more
 


### PR DESCRIPTION
Use footnotes to avoid manually numbering.

Please [_View file_](https://github.com/YDX-2147483647/python-easter-eggs/blob/patch-1/README.md) to see what it'll look like.

Resolves #13

By the way, footnotes' names in the _source_ markdown are quite arbitrary, because they won't be shown after rendering.
